### PR TITLE
Upgrade SS to 5.0.0

### DIFF
--- a/src/ServiceStack.IntroSpec/DemoService/DemoService.csproj
+++ b/src/ServiceStack.IntroSpec/DemoService/DemoService.csproj
@@ -34,42 +34,54 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MsgPack, Version=0.8.0.0, Culture=neutral, PublicKeyToken=a2625990d5dc0167, processorArchitecture=MSIL">
-      <HintPath>..\packages\MsgPack.Cli.0.8.0\lib\net45\MsgPack.dll</HintPath>
+    <Reference Include="MsgPack, Version=0.9.0.0, Culture=neutral, PublicKeyToken=a2625990d5dc0167, processorArchitecture=MSIL">
+      <HintPath>..\packages\MsgPack.Cli.0.9.2\lib\net45\MsgPack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.4.5.4\lib\net45\ServiceStack.dll</HintPath>
+    <Reference Include="ServiceStack, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.5.0.0\lib\net45\ServiceStack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Api.Swagger, Version=4.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Api.Swagger.4.5.0\lib\net45\ServiceStack.Api.Swagger.dll</HintPath>
+    <Reference Include="ServiceStack.Api.Swagger, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Api.Swagger.5.0.0\lib\net45\ServiceStack.Api.Swagger.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.4.5.4\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.5.0.0\lib\net45\ServiceStack.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Common.4.5.4\lib\net45\ServiceStack.Common.dll</HintPath>
+    <Reference Include="ServiceStack.Common, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Common.5.0.0\lib\net45\ServiceStack.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.4.5.4\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.5.0.0\lib\net45\ServiceStack.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.MsgPack, Version=4.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.MsgPack.4.5.0\lib\net45\ServiceStack.MsgPack.dll</HintPath>
+    <Reference Include="ServiceStack.MsgPack, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.MsgPack.5.0.0\lib\net45\ServiceStack.MsgPack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.4.5.4\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.OrmLite, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.OrmLite.5.0.0\lib\net45\ServiceStack.OrmLite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ServiceStack.Razor, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Razor.5.0.0\lib\net45\ServiceStack.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.5.0.0\lib\net45\ServiceStack.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DemoService.cs" />

--- a/src/ServiceStack.IntroSpec/DemoService/packages.config
+++ b/src/ServiceStack.IntroSpec/DemoService/packages.config
@@ -1,11 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MsgPack.Cli" version="0.8.0" targetFramework="net452" />
-  <package id="ServiceStack" version="4.5.4" targetFramework="net452" />
-  <package id="ServiceStack.Api.Swagger" version="4.5.0" targetFramework="net452" />
-  <package id="ServiceStack.Client" version="4.5.4" targetFramework="net452" />
-  <package id="ServiceStack.Common" version="4.5.4" targetFramework="net452" />
-  <package id="ServiceStack.Interfaces" version="4.5.4" targetFramework="net452" />
-  <package id="ServiceStack.MsgPack" version="4.5.0" targetFramework="net452" />
-  <package id="ServiceStack.Text" version="4.5.4" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />
+  <package id="MsgPack.Cli" version="0.9.2" targetFramework="net452" />
+  <package id="ServiceStack" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.Api.Swagger" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.Client" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.Common" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.Interfaces" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.MsgPack" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.OrmLite" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.Razor" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.Text" version="5.0.0" targetFramework="net452" />
 </packages>

--- a/src/ServiceStack.IntroSpec/IntroSpec/IntroSpec/IntroSpec.csproj
+++ b/src/ServiceStack.IntroSpec/IntroSpec/IntroSpec/IntroSpec.csproj
@@ -51,42 +51,54 @@
       <HintPath>..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MsgPack, Version=0.8.0.0, Culture=neutral, PublicKeyToken=a2625990d5dc0167, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MsgPack.Cli.0.8.0\lib\net45\MsgPack.dll</HintPath>
+    <Reference Include="MsgPack, Version=0.9.0.0, Culture=neutral, PublicKeyToken=a2625990d5dc0167, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MsgPack.Cli.0.9.2\lib\net45\MsgPack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.4.5.4\lib\net45\ServiceStack.dll</HintPath>
+    <Reference Include="ServiceStack, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.5.0.0\lib\net45\ServiceStack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Api.Swagger, Version=4.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Api.Swagger.4.5.0\lib\net45\ServiceStack.Api.Swagger.dll</HintPath>
+    <Reference Include="ServiceStack.Api.Swagger, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Api.Swagger.5.0.0\lib\net45\ServiceStack.Api.Swagger.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Client.4.5.4\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Client.5.0.0\lib\net45\ServiceStack.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Common.4.5.4\lib\net45\ServiceStack.Common.dll</HintPath>
+    <Reference Include="ServiceStack.Common, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Common.5.0.0\lib\net45\ServiceStack.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Interfaces.4.5.4\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Interfaces.5.0.0\lib\net45\ServiceStack.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.MsgPack, Version=4.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.MsgPack.4.5.0\lib\net45\ServiceStack.MsgPack.dll</HintPath>
+    <Reference Include="ServiceStack.MsgPack, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.MsgPack.5.0.0\lib\net45\ServiceStack.MsgPack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Text.4.5.4\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.OrmLite, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.OrmLite.5.0.0\lib\net45\ServiceStack.OrmLite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ServiceStack.Razor, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Razor.5.0.0\lib\net45\ServiceStack.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Text.5.0.0\lib\net45\ServiceStack.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />

--- a/src/ServiceStack.IntroSpec/IntroSpec/IntroSpec/Web.config
+++ b/src/ServiceStack.IntroSpec/IntroSpec/IntroSpec/Web.config
@@ -1,13 +1,20 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433
   -->
 <configuration>
+  <configSections>
+    <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
+      <section name="host" type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+      <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+    </sectionGroup>
+  </configSections>
+  
   <appSettings>
-    <add key="vs:EnableBrowserLink" value="false"/>
-    <add key="webPages:Enabled" value="false"/>
-  </appSettings>
+    <add key="vs:EnableBrowserLink" value="false" />
+    
+  <add key="webPages:Enabled" value="false" /></appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 
@@ -17,24 +24,41 @@
       </system.Web>
   -->
   <system.web>
-    <httpRuntime targetFramework="4.5"/>
-    <compilation debug="true" targetFramework="4.5"/>
+    <httpRuntime targetFramework="4.5" />
+    <compilation targetFramework="4.5" debug="true"><buildProviders>
+        <add extension=".cshtml" type="ServiceStack.Razor.CSharpRazorBuildProvider, ServiceStack.Razor" />
+      </buildProviders></compilation>
     <!-- For IIS 6.0/Mono -->
     <httpHandlers>
-      <add path="*" type="ServiceStack.HttpHandlerFactory, ServiceStack" verb="*"/>
+      <add path="*" type="ServiceStack.HttpHandlerFactory, ServiceStack" verb="*" />
     </httpHandlers>
   </system.web>
   <!-- For IIS 7.0+ -->
   <system.webServer>
-    <validation validateIntegratedModeConfiguration="false"/>
+    <validation validateIntegratedModeConfiguration="false" />
     <handlers>
-      <add path="*" name="ServiceStack.Factory" preCondition="integratedMode" type="ServiceStack.HttpHandlerFactory, ServiceStack" verb="*" resourceType="Unspecified" allowPathInfo="true"/>
+      <add path="*" name="ServiceStack.Factory" preCondition="integratedMode" type="ServiceStack.HttpHandlerFactory, ServiceStack" verb="*" resourceType="Unspecified" allowPathInfo="true" />
     </handlers>
   </system.webServer>
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701"/>
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
-</configuration>
+<system.web.webPages.razor>
+    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+    <pages pageBaseType="ServiceStack.Razor.ViewPage">
+      <namespaces>
+        <add namespace="System" />
+        <add namespace="System.Linq" />
+        <add namespace="ServiceStack" />
+        <add namespace="ServiceStack.Html" />
+        <add namespace="ServiceStack.Razor" />
+        <add namespace="ServiceStack.Text" />
+        <add namespace="ServiceStack.OrmLite" />
+        <add namespace="IntroSpec" />
+        <add namespace="IntroSpec.ServiceModel" />
+      </namespaces>
+    </pages>
+  </system.web.webPages.razor></configuration>

--- a/src/ServiceStack.IntroSpec/IntroSpec/IntroSpec/packages.config
+++ b/src/ServiceStack.IntroSpec/IntroSpec/IntroSpec/packages.config
@@ -1,13 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
-  <package id="MsgPack.Cli" version="0.8.0" targetFramework="net45" />
-  <package id="ServiceStack" version="4.5.4" targetFramework="net45" />
-  <package id="ServiceStack.Api.Swagger" version="4.5.0" targetFramework="net45" />
-  <package id="ServiceStack.Client" version="4.5.4" targetFramework="net45" />
-  <package id="ServiceStack.Common" version="4.5.4" targetFramework="net45" />
-  <package id="ServiceStack.Interfaces" version="4.5.4" targetFramework="net45" />
-  <package id="ServiceStack.MsgPack" version="4.5.0" targetFramework="net45" />
-  <package id="ServiceStack.Text" version="4.5.4" targetFramework="net45" />
+  <package id="MsgPack.Cli" version="0.9.2" targetFramework="net45" />
+  <package id="ServiceStack" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.Api.Swagger" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.Client" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.Common" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.Interfaces" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.MsgPack" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.OrmLite" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.Razor" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.Text" version="5.0.0" targetFramework="net45" />
 </packages>

--- a/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec.Tests/Enrichers/ReflectionEnricherTests.cs
+++ b/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec.Tests/Enrichers/ReflectionEnricherTests.cs
@@ -320,13 +320,10 @@ namespace ServiceStack.IntroSpec.Tests.Enrichers
             var operation = new Operation { RequestType = typeof(SomeAttributes) };
             var contentTypes = enricher.GetContentTypes(operation, Verb);
 
-            contentTypes.Length.Should().Be(6);
+            contentTypes.Length.Should().Be(3);
             contentTypes.Should().Contain(MimeTypes.Xml)
                         .And.Contain(MimeTypes.Json)
-                        .And.Contain(MimeTypes.Jsv)
-                        .And.Contain(MimeTypes.Soap11)
-                        .And.Contain(MimeTypes.Soap12)
-                        .And.Contain(MimeTypes.Csv);
+                        .And.Contain(MimeTypes.Jsv);
         }
 
         [Fact]
@@ -351,11 +348,10 @@ namespace ServiceStack.IntroSpec.Tests.Enrichers
             var operation = new Operation { RequestType = typeof(AllAttributes) };
             var contentTypes = enricher.GetContentTypes(operation, Verb);
 
-            contentTypes.Length.Should().Be(4);
+            contentTypes.Length.Should().Be(3);
             contentTypes.Should().Contain(MimeTypes.Xml)
                         .And.Contain(MimeTypes.Json)
-                        .And.Contain(MimeTypes.Jsv)
-                        .And.Contain(MimeTypes.Csv);
+                        .And.Contain(MimeTypes.Jsv);
         }
 
         [Fact]

--- a/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec.Tests/Extensions/OperationExtensionsTests.cs
+++ b/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec.Tests/Extensions/OperationExtensionsTests.cs
@@ -60,7 +60,7 @@ namespace ServiceStack.IntroSpec.Tests.Extensions
         {
             var operation = new Operation
             {
-                RequestFilterAttributes = new List<IHasRequestFilter> { new AuthenticateAttribute() }
+                RequestFilterAttributes = new List<IRequestFilterBase> { new AuthenticateAttribute() }
             };
             operation.AuthenticationAppliesForVerb("GET").Should().BeTrue();
         }
@@ -74,7 +74,7 @@ namespace ServiceStack.IntroSpec.Tests.Extensions
         {
             var operation = new Operation
             {
-                RequestFilterAttributes = new List<IHasRequestFilter> { new AuthenticateAttribute(applyTo) }
+                RequestFilterAttributes = new List<IRequestFilterBase> { new AuthenticateAttribute(applyTo) }
             };
             operation.AuthenticationAppliesForVerb(verb).Should().BeTrue();
         }
@@ -84,7 +84,7 @@ namespace ServiceStack.IntroSpec.Tests.Extensions
         {
             var operation = new Operation
             {
-                RequestFilterAttributes = new List<IHasRequestFilter> { new AuthenticateAttribute(ApplyTo.Get) }
+                RequestFilterAttributes = new List<IRequestFilterBase> { new AuthenticateAttribute(ApplyTo.Get) }
             };
             operation.AuthenticationAppliesForVerb("POST").Should().BeFalse();
         }
@@ -94,7 +94,7 @@ namespace ServiceStack.IntroSpec.Tests.Extensions
         {
             var operation = new Operation
             {
-                RequestFilterAttributes = new List<IHasRequestFilter> { new AuthenticateAttribute(ApplyTo.Get) }
+                RequestFilterAttributes = new List<IRequestFilterBase> { new AuthenticateAttribute(ApplyTo.Get) }
             };
             operation.AuthenticationAppliesForVerb("FOO").Should().BeFalse();
         }
@@ -132,7 +132,7 @@ namespace ServiceStack.IntroSpec.Tests.Extensions
             var operation = new Operation
             {
                 RequestFilterAttributes =
-                    new List<IHasRequestFilter>
+                    new List<IRequestFilterBase>
                     {
                         new RequiresAnyRoleAttribute(ApplyTo.Delete),
                         new RequiredRoleAttribute(ApplyTo.Get)
@@ -149,7 +149,7 @@ namespace ServiceStack.IntroSpec.Tests.Extensions
             var operation = new Operation
             {
                 RequestFilterAttributes =
-                    new List<IHasRequestFilter>
+                    new List<IRequestFilterBase>
                     {
                         new RequiresAnyRoleAttribute(ApplyTo.Delete, roles)
                     }
@@ -167,7 +167,7 @@ namespace ServiceStack.IntroSpec.Tests.Extensions
             var operation = new Operation
             {
                 RequestFilterAttributes =
-                    new List<IHasRequestFilter>
+                    new List<IRequestFilterBase>
                     {
                         new RequiredRoleAttribute(ApplyTo.Delete, roles)
                     }
@@ -185,7 +185,7 @@ namespace ServiceStack.IntroSpec.Tests.Extensions
             var operation = new Operation
             {
                 RequestFilterAttributes =
-                    new List<IHasRequestFilter>
+                    new List<IRequestFilterBase>
                     {
                         new RequiredRoleAttribute(ApplyTo.Delete, roles),
                         new RequiresAnyRoleAttribute(ApplyTo.Delete, roles)
@@ -206,7 +206,7 @@ namespace ServiceStack.IntroSpec.Tests.Extensions
             var operation = new Operation
             {
                 RequestFilterAttributes =
-                    new List<IHasRequestFilter>
+                    new List<IRequestFilterBase>
                     {
                         new RequiresAnyPermissionAttribute(ApplyTo.Delete),
                         new RequiredPermissionAttribute(ApplyTo.Get)
@@ -223,7 +223,7 @@ namespace ServiceStack.IntroSpec.Tests.Extensions
             var operation = new Operation
             {
                 RequestFilterAttributes =
-                    new List<IHasRequestFilter>
+                    new List<IRequestFilterBase>
                     {
                         new RequiresAnyPermissionAttribute(ApplyTo.Delete, roles)
                     }
@@ -241,7 +241,7 @@ namespace ServiceStack.IntroSpec.Tests.Extensions
             var operation = new Operation
             {
                 RequestFilterAttributes =
-                    new List<IHasRequestFilter>
+                    new List<IRequestFilterBase>
                     {
                         new RequiredPermissionAttribute(ApplyTo.Delete, roles)
                     }
@@ -259,7 +259,7 @@ namespace ServiceStack.IntroSpec.Tests.Extensions
             var operation = new Operation
             {
                 RequestFilterAttributes =
-                    new List<IHasRequestFilter>
+                    new List<IRequestFilterBase>
                     {
                         new RequiredPermissionAttribute(ApplyTo.Delete, roles),
                         new RequiresAnyPermissionAttribute(ApplyTo.Delete, roles)

--- a/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec.Tests/Fixtures/AppHostFixture.cs
+++ b/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec.Tests/Fixtures/AppHostFixture.cs
@@ -30,6 +30,8 @@ namespace ServiceStack.IntroSpec.Tests.Fixtures
                 ServiceName = ServiceName
             };
 
+            AppHost.Plugins.Add(new MetadataFeature());
+
             AppHost.Init();
             AppHost.Config.WebHostUrl = WebHostUrl;
             var hal = "hal+json";

--- a/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec.Tests/ServiceStack.IntroSpec.Tests.csproj
+++ b/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec.Tests/ServiceStack.IntroSpec.Tests.csproj
@@ -45,30 +45,42 @@
       <HintPath>..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.4.5.4\lib\net45\ServiceStack.dll</HintPath>
+    <Reference Include="ServiceStack, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.5.0.0\lib\net45\ServiceStack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.4.5.4\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.5.0.0\lib\net45\ServiceStack.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Common.4.5.4\lib\net45\ServiceStack.Common.dll</HintPath>
+    <Reference Include="ServiceStack.Common, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Common.5.0.0\lib\net45\ServiceStack.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.4.5.4\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.5.0.0\lib\net45\ServiceStack.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.4.5.4\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.OrmLite, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.OrmLite.5.0.0\lib\net45\ServiceStack.OrmLite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ServiceStack.Razor, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Razor.5.0.0\lib\net45\ServiceStack.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.5.0.0\lib\net45\ServiceStack.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec.Tests/packages.config
+++ b/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec.Tests/packages.config
@@ -2,11 +2,14 @@
 <packages>
   <package id="FakeItEasy" version="2.3.1" targetFramework="net452" />
   <package id="FluentAssertions" version="4.14.0" targetFramework="net452" />
-  <package id="ServiceStack" version="4.5.4" targetFramework="net452" />
-  <package id="ServiceStack.Client" version="4.5.4" targetFramework="net452" />
-  <package id="ServiceStack.Common" version="4.5.4" targetFramework="net452" />
-  <package id="ServiceStack.Interfaces" version="4.5.4" targetFramework="net452" />
-  <package id="ServiceStack.Text" version="4.5.4" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />
+  <package id="ServiceStack" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.Client" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.Common" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.Interfaces" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.OrmLite" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.Razor" version="5.0.0" targetFramework="net452" />
+  <package id="ServiceStack.Text" version="5.0.0" targetFramework="net452" />
   <package id="xunit" version="2.0.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.0.0" targetFramework="net452" />

--- a/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec/Extensions/OperationExtensions.cs
+++ b/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec/Extensions/OperationExtensions.cs
@@ -68,7 +68,7 @@ namespace ServiceStack.IntroSpec.Extensions
             return Permissions.Create(any, all);
         }
 
-        private static IEnumerable<T> GetRequestAttr<T>(this Operation operation) where T : IHasRequestFilter
+        private static IEnumerable<T> GetRequestAttr<T>(this Operation operation) where T : IRequestFilterBase
             => operation.RequestFilterAttributes?.OfType<T>();
 
         private static List<string> GetRoles<T>(this Operation operation, string verb,

--- a/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec/Postman/Services/PostmanCollectionGenerator.cs
+++ b/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec/Postman/Services/PostmanCollectionGenerator.cs
@@ -92,7 +92,7 @@ namespace ServiceStack.IntroSpec.Postman.Services
 
                     log.Debug($"Generating PostmanRequest for resource {resource.Title}, {action}");
 
-                    var hasRequestBody = action.Verb.HasRequestBody();
+                    var hasRequestBody = HttpUtils.HasRequestBody(action.Verb);
                     if (!hasRequestBody)
                         relativePath = ProcessQueryStringParams(data, pathVariableNames, relativePath);
 

--- a/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec/ServiceStack.IntroSpec.csproj
+++ b/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec/ServiceStack.IntroSpec.csproj
@@ -31,30 +31,42 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ServiceStack, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.4.5.4\lib\net45\ServiceStack.dll</HintPath>
+    <Reference Include="ServiceStack, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.5.0.0\lib\net45\ServiceStack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.4.5.4\lib\net45\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.5.0.0\lib\net45\ServiceStack.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Common.4.5.4\lib\net45\ServiceStack.Common.dll</HintPath>
+    <Reference Include="ServiceStack.Common, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Common.5.0.0\lib\net45\ServiceStack.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.4.5.4\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.5.0.0\lib\net45\ServiceStack.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.5.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.4.5.4\lib\net45\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.OrmLite, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.OrmLite.5.0.0\lib\net45\ServiceStack.OrmLite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ServiceStack.Razor, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Razor.5.0.0\lib\net45\ServiceStack.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.5.0.0\lib\net45\ServiceStack.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec/ServiceStack.IntroSpec.nuspec
+++ b/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec/ServiceStack.IntroSpec.nuspec
@@ -12,7 +12,7 @@
     <tags>servicestack microservices introspection documentation spec specification api postman</tags>
     <releaseNotes>See github project for details</releaseNotes>
     <dependencies>
-      <dependency id="ServiceStack" version="[4.0.56, 5)" />
+      <dependency id="ServiceStack" version="[5, 6)" />
     </dependencies>
   </metadata>
 </package>

--- a/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec/packages.config
+++ b/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec/packages.config
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ServiceStack" version="4.5.4" targetFramework="net45" />
-  <package id="ServiceStack.Client" version="4.5.4" targetFramework="net45" />
-  <package id="ServiceStack.Common" version="4.5.4" targetFramework="net45" />
-  <package id="ServiceStack.Interfaces" version="4.5.4" targetFramework="net45" />
-  <package id="ServiceStack.Text" version="4.5.4" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
+  <package id="ServiceStack" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.Client" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.Common" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.Interfaces" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.OrmLite" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.Razor" version="5.0.0" targetFramework="net45" />
+  <package id="ServiceStack.Text" version="5.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Upgrade to have dep on SS 5 to 6. As there were structural changes in SS v5 I've "followed" these changes and reflected them in the source (classes moved between deps, different default plugins, different default content types).

I'm not sure how you supposed to continue to support v4 as a plugin vendor, I presume this will require different NuGet packages.
