### PR TITLE
Fix populate embedded resource when type has non-system type generic args

### DIFF
--- a/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec.Tests/Enrichers/Infrastructure/PropertyEnricherManagerTests.cs
+++ b/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec.Tests/Enrichers/Infrastructure/PropertyEnricherManagerTests.cs
@@ -13,6 +13,7 @@ namespace ServiceStack.IntroSpec.Tests.Enrichers.Infrastructure
     using IntroSpec.Enrichers.Interfaces;
     using IntroSpec.Models;
     using Xunit;
+    using System.Collections.Generic;
 
     public class PropertyEnricherManagerTests
     {
@@ -298,6 +299,18 @@ namespace ServiceStack.IntroSpec.Tests.Enrichers.Infrastructure
         }
 
         [Fact]
+        public void EnrichParameters_CallsEnrichResource_IfTypeIsSystemTypeButHasAGenericArgumentThatIsNot()
+        {
+            var param = GetApiParameterDocumention();
+
+            bool called = false;
+            var enricherManager = new PropertyEnricherManager(propertyEnricher, (resource, resourceModel) => { called = true; });
+
+            enricherManager.EnrichParameters(new[] { param }, new ResourceModel(typeof(SingleGenericProp), false));
+            called.Should().BeTrue();
+        }
+
+        [Fact]
         public void EnrichParameters_SetsTypeName_WhenCallingEnrichResource()
         {
             var param = GetApiParameterDocumention();
@@ -409,5 +422,13 @@ namespace ServiceStack.IntroSpec.Tests.Enrichers.Infrastructure
     public class SelfReference
     {
         public SelfReference Child { get; set; }
+    }
+
+    public class SingleGenericProp
+    {
+        [IgnoreDataMember]
+        public string S { get; set; }
+
+        public List<NoProps> X { get; set; }
     }
 }

--- a/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec/Enrichers/Infrastructure/PropertyEnricherManager.cs
+++ b/src/ServiceStack.IntroSpec/ServiceStack.IntroSpec/Enrichers/Infrastructure/PropertyEnricherManager.cs
@@ -135,7 +135,7 @@ namespace ServiceStack.IntroSpec.Enrichers.Infrastructure
 
         // Avoid populating if SystemType, enum or embedded property type == parent resource type
         private bool ShouldPopulateEmbeddedResource(Type embeddedType, Type resourceType)
-            => !(embeddedType.IsSystemType() || embeddedType.IsEnum || embeddedType == resourceType);
+            => !((embeddedType.IsGenericType ? embeddedType.IsSystemType() && embeddedType.GenericTypeArguments.All(t => t.IsSystemType()) : embeddedType.IsSystemType()) || embeddedType.IsEnum || embeddedType == resourceType);
 
     }
 }


### PR DESCRIPTION
`List<CustomModel>` would not populate `EmbeddedResource` as `List` is a system type. This fix checks the generic arguments, if they are not system types the type will populate `EmbeddedResource`.
